### PR TITLE
Update hostname

### DIFF
--- a/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
+++ b/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
@@ -30,7 +30,7 @@ end
 
 %>
 
-hostname: "-"
+hostname: <%= spec.address %>
 structured_data: "[instance@47450 director=\"<%= p('syslog.director') %>\" deployment=\"<%= spec.deployment %>\" group=\"<%= spec.name %>\" az=\"<%= spec.az %>\" id=\"<%= spec.id %>\"]"
 syslog:
   source_dir: <%= p("syslog.blackbox.source_dir") %>


### PR DESCRIPTION
Instead of hard coding the hostname to "-", read it from spec.address
to match how it is done on Linux.

It's worth noting that on Windows, spec.address returns the internal IP
of the instance, whereas on Linux it returns a formatted string
including the instance ID and instance name. We believe the BOSH Agent
on Windows should be updated so that spec.address returns the same
format as Linux.

[#160740764]

Signed-off-by: Natalie Arellano <narellano@pivotal.io>