### PR TITLE
Exclude files for windows

### DIFF
--- a/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
+++ b/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
@@ -38,5 +38,6 @@ syslog:
     transport: <%= syslog_transport %>
     address:  <%= syslog_address %>:<%= syslog_port %>
     ca: <%= syslog_ca %>
+  exclude_file_pattern: '*.[0-9].log'
 
 <% end %>

--- a/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
+++ b/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
@@ -38,6 +38,6 @@ syslog:
     transport: <%= syslog_transport %>
     address:  <%= syslog_address %>:<%= syslog_port %>
     ca: <%= syslog_ca %>
-  exclude_file_pattern: '*.[0-9].log'
+  exclude_file_pattern: '*.[0-9].*.log'
 
 <% end %>


### PR DESCRIPTION
We found that on Windows, blackbox will try to tail the rotated log files that have names like
job-service-wrapper.0.out.log, resulting in duplicate log lines in the syslog sink.

This PR will set the pattern of files to exclude to `*.[0-9].*.log`

This is a follow up to the PR we submitted to blackbox here: https://github.com/cloudfoundry/blackbox/pull/10

Tracker story: #161665842