### PR TITLE
fix for go 1.18

### DIFF
--- a/packages/blackbox-windows/spec
+++ b/packages/blackbox-windows/spec
@@ -1,6 +1,8 @@
 ---
 name: blackbox-windows
 dependencies:
-  - golang-1-windows
+- golang-1-windows
 files:
-  - blackbox/**/*
+- blackbox/**/*
+excluded_files:
+- blackbox/.git

--- a/scripts/test
+++ b/scripts/test
@@ -6,11 +6,11 @@ pushd "$(dirname "$0")/.."
   bosh create-release --force --version="$(date "+%s")"
   bosh upload-release
 popd
-bosh upload-stemcell --sha1 256e2629f2f949d3fc1b9f03a4b9f60ce88520a8 https://bosh.io/d/stemcells/bosh-google-kvm-windows2019-go_agent?v=2019.36
-bosh upload-release --sha1 9bf48ad25843e29dc76437fe89a35c550746fd22 https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11.7.0
-bosh upload-release --sha1 7886ffd43b84d4eced06560ba601ce1eb97c6616 https://bosh.io/d/github.com/cloudfoundry-incubator/windows-utilities-release?v=0.14.0
+bosh upload-stemcell https://bosh.io/d/stemcells/bosh-google-kvm-windows2019-go_agent
+bosh upload-release https://bosh.io/d/github.com/cloudfoundry/syslog-release
+bosh upload-release https://bosh.io/d/github.com/cloudfoundry-incubator/windows-utilities-release
 
-go get -u github.com/onsi/ginkgo/ginkgo
 pushd "$(dirname "$0")/../tests"
+  go install github.com/onsi/ginkgo/ginkgo@latest
   ginkgo -r -nodes=2 "$@"
 popd


### PR DESCRIPTION
- letting the pipeline do the actual golang bump and tests

- go tries to include git information but stemcells do not include git binary
  https://github.com/golang/go/issues/51748

- go install instead of go get for installing in go 1.18

Signed-off-by: Ben Fuller <benjaminf@vmware.com>
Co-authored-by: Ben Fuller <benjaminf@vmware.com>

# Description

Please include a summary of the change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

