### PR TITLE
Include optional environment identifier

### DIFF
--- a/jobs/syslog_forwarder_windows/spec
+++ b/jobs/syslog_forwarder_windows/spec
@@ -19,7 +19,9 @@ properties:
       String to be used in "director" field
       in structured data of forwarded logs.
     default: ""
-
+  syslog.environment:
+    description: "Optional environment identifier"
+    default: ""
   syslog.transport:
     description: >
       Protocol that will be used when forwarding loglines

--- a/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
+++ b/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
@@ -36,6 +36,9 @@ structured_data_id: "instance@47450"
 structured_data_map:
   deployment: <%= spec.deployment %>
   director: <%= p('syslog.director') %>
+<% if p('syslog.environment') != '' -%>
+  environment: "<%= p('syslog.environment') %>"
+<% end -%>
   group: <%= spec.name %>
   az: <%= spec.az %>
   id: <%= spec.id %>

--- a/tests/acceptance_test.go
+++ b/tests/acceptance_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Forwarding Loglines", func() {
 	})
 
 	It("annotates logs with structured data specific to the instance", func() {
-		ExpectedStructuredDataRegexp := fmt.Sprintf("\\[instance@47450 az=\".*\" deployment=\"%s\" director=\"test-env\" group=\"forwarder\" id=\".*\"\\]", DeploymentName())
+		ExpectedStructuredDataRegexp := fmt.Sprintf(`\[instance@47450 az=".*" deployment="%s" director="test-env" environment="some-environment-identifier" group="forwarder" id=".*"\]`, DeploymentName())
 		message := counterString(500, "A")
 		Eventually(WriteToTestFile(message)).Should(MatchRegexp(ExpectedStructuredDataRegexp))
 	})

--- a/tests/manifests/tcp.yml
+++ b/tests/manifests/tcp.yml
@@ -31,6 +31,7 @@ instance_groups:
         properties:
           syslog:
             director: "test-env"
+            environment: "some-environment-identifier"
       - name: enable_ssh
         release: windows-utilities
       - name: enable_rdp


### PR DESCRIPTION
# Description

- Operators are already able to tag emitted log lines with the BOSH Director name with the `director` structured data parameter.
- Add a new `environment` structured data parameter for cases where log lines should be tagged with an operator provided string but need to vary from the director name.
- Don't add the environment SD-PARAM when the BOSH property is not provided by the operator. This prevents any log parsing breakage that might occur if log processors were to be string matching rather than parsing syslog messages correctly.

See also https://github.com/cloudfoundry/syslog-release/pull/153.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
