### PR TITLE
feat: add configurable retries with exponential backoff

### DIFF
--- a/jobs/syslog_forwarder_windows/spec
+++ b/jobs/syslog_forwarder_windows/spec
@@ -63,6 +63,10 @@ properties:
     description: limit goprocess to a single cpu via gomaxprocs
     default: true
 
+  syslog.blackbox.max_retries:
+    description: maximum number of times to retry the connection with an exponential backoff between attempts
+    default: 10
+
   syslog.migration.disabled:
     default: false
     description: |

--- a/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
+++ b/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
@@ -48,6 +48,7 @@ syslog:
     transport: <%= syslog_transport %>
     address:  <%= syslog_address %>:<%= syslog_port %>
     ca: <%= syslog_ca %>
+    max_retries: <%= p("syslog.blackbox.max_retries") %>
   exclude_file_pattern: '*.[0-9].*.log'
 
 <% end %>


### PR DESCRIPTION
# Description

On windows blackbox was preventing log rotation when configured with invalid syslog credentials as it was locking the file while trying to endlessly reconnect. This change makes it so that blackbox exits which unlocks the file and indicates that the config is invalid.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
