### PR TITLE
chore: Bump to Go1.22

### DIFF
--- a/packages/blackbox-windows/packaging
+++ b/packages/blackbox-windows/packaging
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
-. C:\var\vcap\packages\golang-1.21-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-1.22-windows\bosh\compile.ps1
 
 $BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
 cd blackbox\cmd\blackbox

--- a/packages/blackbox-windows/spec
+++ b/packages/blackbox-windows/spec
@@ -1,7 +1,7 @@
 ---
 name: blackbox-windows
 dependencies:
-- golang-1.21-windows
+- golang-1.22-windows
 files:
 - blackbox/**/*
 excluded_files:

--- a/packages/golang-1.21-windows/spec.lock
+++ b/packages/golang-1.21-windows/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.21-windows
-fingerprint: 9a0e2afc1a8bcb7d81895e6706ab1faa8b72b9209a1843c9da5b3d1d12088622

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module windows_syslog_acceptance_test
 
-go 1.21
+go 1.22
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0


### PR DESCRIPTION
# Description

- Removes go1.21 packages
- Uses go1.22 packages to build the other packages

## Type of change

- [x] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
